### PR TITLE
Enable Null Safety for Dart 3

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -33,8 +33,8 @@ class SidebarPage extends StatefulWidget {
 }
 
 class _SidebarPageState extends State<SidebarPage> {
-  List<CollapsibleItem> _items;
-  String _headline;
+  late List<CollapsibleItem> _items;
+  late String _headline;
   AssetImage _avatarImg = AssetImage('assets/man.png');
 
   @override

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,7 +8,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
+// import 'package:example/main.dart';
+import '../lib/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -161,5 +161,5 @@ packages:
     source: hosted
     version: "2.1.4"
 sdks:
-  dart: ">=2.18.0 <4.0.0"
+  dart: ">=2.18.0 <3.0.0"
   flutter: ">=1.17.0"


### PR DESCRIPTION
This includes changes for dart 3.0 requiring null safety. To create these changes, I followed Dart's [instructions on migrating to null safety](https://dart.dev/null-safety/migration-guide#step2-migrate). 

In short, the process I used was:

- Run `dart migrate` in the root directory (same directory where `pubspec.yaml` is located)
- Fix any errors found
- Repeat the process until no errors are found